### PR TITLE
Inputs as settings

### DIFF
--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -1375,7 +1375,8 @@ function CommitFromNewFolder {
         [string] $serverUrl,
         [string] $commitMessage,
         [string] $body = $commitMessage,
-        [string] $branch
+        [string] $branch,
+        [string] $customSuffix
     )
 
     invoke-git add *
@@ -1385,9 +1386,9 @@ function CommitFromNewFolder {
 
         # Add commit message suffix if specified in settings
         $settings = ReadSettings
-        if ($settings.commitOptions.messageSuffix) {
-            $commitMessage = "$commitMessage / $($settings.commitOptions.messageSuffix)"
-            $body = "$body`n$($settings.commitOptions.messageSuffix)"
+        if ($customSuffix) {
+            $commitMessage = "$commitMessage / $customSuffix"
+            $body = "$body`n$customSuffix"
         }
 
         if ($commitMessage.Length -gt 250) {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -711,18 +711,20 @@ function ReadSettings {
         }
     }
     if($eventName -eq "workflow_dispatch") {
-        # Read the inputs from the workflow_dispatch event using the GITHUB_EVENT_PATH
-        $eventPath = "$env:GITHUB_EVENT_PATH"
         if (Test-Path $eventPath) {
             # Print Get-Content $eventPath -Raw to log
             Write-Host "Workflow Dispatch Event:"
             Write-Host (Get-Content $eventPath -Raw)
             $workflowDispatchEvent = Get-Content $eventPath -Raw | ConvertFrom-Json
-            $inputs = @($workflowDispatchEvent.inputs)
-            # Print all the inputs to the log
-            $inputs | ForEach-Object {
-                Write-Host "Input: $($_.key) = $($_.value)"
+            # Check if there are inputs in the workflow_dispatch event
+            if ($workflowDispatchEvent.inputs) {
+                Write-Host "Applying settings from input"
+                $settingsObjects += @($workflowDispatchEvent.inputs)
+            } else {
+                Write-Host "No settings found in input"
             }
+        } else {
+            Write-Host "Workflow was scheduled. Ignoring input settings."
         }
     }
     foreach($settingsJson in $settingsObjects) {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -512,9 +512,7 @@ function ReadSettings {
         [string] $workflowName = "$ENV:GITHUB_WORKFLOW",
         [string] $userName = "$ENV:GITHUB_ACTOR",
         [string] $branchName = "$ENV:GITHUB_REF_NAME",
-        [string] $orgSettingsVariableValue = "$ENV:ALGoOrgSettings",
-        [string] $repoSettingsVariableValue = "$ENV:ALGoRepoSettings",
-        [string] $eventName = "$ENV:GITHUB_EVENT_NAME"
+        [string] $orgSettingsVariableValue = "$ENV:ALGoOrgSettings"
     )
 
     # If the build is triggered by a pull request the refname will be the merge branch. To apply conditional settings we need to use the base branch

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -805,6 +805,7 @@ function ReadInputs {
     )
 
     # If the event is a workflow_dispatch event, read the inputs from the event file
+    # If the workflow is triggered in other ways (e.g. push, schedule), the inputs are not available
     if(($eventName -eq "workflow_dispatch") -and (Test-Path $eventPath)) {
         $workflowDispatchEvent = Get-Content $eventPath -Raw | ConvertFrom-Json
         if ($workflowDispatchEvent.inputs) {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -512,7 +512,8 @@ function ReadSettings {
         [string] $workflowName = "$ENV:GITHUB_WORKFLOW",
         [string] $userName = "$ENV:GITHUB_ACTOR",
         [string] $branchName = "$ENV:GITHUB_REF_NAME",
-        [string] $orgSettingsVariableValue = "$ENV:ALGoOrgSettings"
+        [string] $orgSettingsVariableValue = "$ENV:ALGoOrgSettings",
+        [string] $repoSettingsVariableValue = "$ENV:ALGoRepoSettings"
     )
 
     # If the build is triggered by a pull request the refname will be the merge branch. To apply conditional settings we need to use the base branch

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -513,7 +513,8 @@ function ReadSettings {
         [string] $userName = "$ENV:GITHUB_ACTOR",
         [string] $branchName = "$ENV:GITHUB_REF_NAME",
         [string] $orgSettingsVariableValue = "$ENV:ALGoOrgSettings",
-        [string] $repoSettingsVariableValue = "$ENV:ALGoRepoSettings"
+        [string] $repoSettingsVariableValue = "$ENV:ALGoRepoSettings",
+        [string] $eventName = "$ENV:GITHUB_EVENT_NAME"
     )
 
     # If the build is triggered by a pull request the refname will be the merge branch. To apply conditional settings we need to use the base branch
@@ -707,6 +708,21 @@ function ReadSettings {
             # Read settings from user settings file
             $userSettingsObject = GetSettingsObject -Path (Join-Path $projectFolder "$ALGoFolderName/$userName.settings.json")
             $settingsObjects += @($projectWorkflowSettingsObject, $userSettingsObject)
+        }
+    }
+    if($eventName -eq "workflow_dispatch") {
+        # Read the inputs from the workflow_dispatch event using the GITHUB_EVENT_PATH
+        $eventPath = "$env:GITHUB_EVENT_PATH"
+        if (Test-Path $eventPath) {
+            # Print Get-Content $eventPath -Raw to log
+            Write-Host "Workflow Dispatch Event:"
+            Write-Host (Get-Content $eventPath -Raw)
+            $workflowDispatchEvent = Get-Content $eventPath -Raw | ConvertFrom-Json
+            $inputs = @($workflowDispatchEvent.inputs)
+            # Print all the inputs to the log
+            $inputs | ForEach-Object {
+                Write-Host "Input: $($_.key) = $($_.value)"
+            }
         }
     }
     foreach($settingsJson in $settingsObjects) {

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -806,7 +806,7 @@ function ReadInputs {
     )
 
     # If the event is a workflow_dispatch event, read the inputs from the event file
-    if(($eventName -eq "workflow_dispatch") -and (Test-Path $eventPath)) {
+    if(($eventName -eq "workflow_dispatch1") -and (Test-Path $eventPath)) {
         $workflowDispatchEvent = Get-Content $eventPath -Raw | ConvertFrom-Json
         if ($workflowDispatchEvent.inputs) {
             return $workflowDispatchEvent.inputs

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -804,7 +804,7 @@ function ReadInputs {
     )
 
     # If the event is a workflow_dispatch event, read the inputs from the event file
-    if(($eventName -eq "workflow_dispatch1") -and (Test-Path $eventPath)) {
+    if(($eventName -eq "workflow_dispatch") -and (Test-Path $eventPath)) {
         $workflowDispatchEvent = Get-Content $eventPath -Raw | ConvertFrom-Json
         if ($workflowDispatchEvent.inputs) {
             return $workflowDispatchEvent.inputs

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -663,6 +663,7 @@ function ReadSettings {
         }
         "trustMicrosoftNuGetFeeds"                      = $true
         "commitOptions"                                 = [ordered]@{
+            "directCommit"                              = $false
             "messageSuffix"                             = ""
             "pullRequestAutoMerge"                      = $false
             "pullRequestLabels"                         = @()

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -674,6 +674,8 @@ function ReadSettings {
         }
         "useGitSubmodules"                              = "false"
         "gitSubmodulesTokenSecretName"                  = "gitSubmodulesToken"
+        "directCommit"                                  = $false
+        "downloadLatest"                                = $false
     }
 
     # Read settings from files and merge them into the settings object

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -674,8 +674,8 @@ function ReadSettings {
         }
         "useGitSubmodules"                              = "false"
         "gitSubmodulesTokenSecretName"                  = "gitSubmodulesToken"
-        "directCommit"                                  = $false
-        "downloadLatest"                                = $false
+        "directCommit"                                  = "false"
+        "downloadLatest"                                = "false"
     }
 
     # Read settings from files and merge them into the settings object

--- a/Actions/AL-Go-Helper.ps1
+++ b/Actions/AL-Go-Helper.ps1
@@ -711,6 +711,7 @@ function ReadSettings {
         }
     }
     if($eventName -eq "workflow_dispatch") {
+        $eventPath = $env:GITHUB_EVENT_PATH
         if (Test-Path $eventPath) {
             # Print Get-Content $eventPath -Raw to log
             Write-Host "Workflow Dispatch Event:"

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -262,7 +262,7 @@ else {
 
         Write-Host "Commit suffix: $commitMessageSuffix"
 
-        if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes)) {
+        if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes -customSuffix $commitMessageSuffix)) {
             OutputWarning "No updates available for AL-Go for GitHub."
         }
     }

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -260,8 +260,6 @@ else {
         Write-Host "ReleaseNotes:"
         Write-Host $releaseNotes
 
-        Write-Host "Commit suffix: $commitMessageSuffix"
-
         if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes -customSuffix $commitMessageSuffix)) {
             OutputWarning "No updates available for AL-Go for GitHub."
         }

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -12,7 +12,9 @@
     [Parameter(HelpMessage = "Set the branch to update", Mandatory = $false)]
     [string] $updateBranch,
     [Parameter(HelpMessage = "Direct Commit?", Mandatory = $false)]
-    [bool] $directCommit
+    [bool] $directCommit,
+    [Parameter(HelpMessage = "Suffix to add to the commit message", Mandatory = $false)]
+    [string] $commitMessageSuffix = ""
 )
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\AL-Go-Helper.ps1" -Resolve)
@@ -257,6 +259,8 @@ else {
 
         Write-Host "ReleaseNotes:"
         Write-Host $releaseNotes
+
+        Write-Host "Commit suffix: $commitMessageSuffix"
 
         if (!(CommitFromNewFolder -serverUrl $serverUrl -commitMessage $commitMessage -branch $branch -body $releaseNotes)) {
             OutputWarning "No updates available for AL-Go for GitHub."

--- a/Actions/CheckForUpdates/action.yaml
+++ b/Actions/CheckForUpdates/action.yaml
@@ -36,6 +36,10 @@ inputs:
     description: Direct Commit?
     required: false
     default: 'false'
+  commitMessageSuffix:
+    description: Commit Message Suffix
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -49,9 +53,10 @@ runs:
         _update: ${{ inputs.update }}
         _updateBranch: ${{ inputs.updateBranch }}
         _directCommit: ${{ inputs.directCommit }}
+        _commitMessageSuffix: ${{ inputs.commitMessageSuffix }}
       run: |
         ${{ github.action_path }}/../Invoke-AlGoAction.ps1 -ActionName "CheckForUpdates" -Action {
-          ${{ github.action_path }}/CheckForUpdates.ps1 -actor $ENV:_actor -token $ENV:_token -templateUrl $ENV:_templateUrl -downloadLatest ($ENV:_downloadLatest -eq 'true') -update $ENV:_update -updateBranch $ENV:_updateBranch -directCommit ($ENV:_directCommit -eq 'true')
+          ${{ github.action_path }}/CheckForUpdates.ps1 -actor $ENV:_actor -token $ENV:_token -templateUrl $ENV:_templateUrl -downloadLatest ($ENV:_downloadLatest -eq 'true') -update $ENV:_update -updateBranch $ENV:_updateBranch -directCommit ($ENV:_directCommit -eq 'true') -commitMessageSuffix "$($ENV:_commitMessageSuffix)"
         }
 branding:
   icon: terminal

--- a/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/AppSource App/.github/workflows/CreateApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateApp.yaml
@@ -90,7 +90,7 @@ jobs:
           publisher: ${{ github.event.inputs.publisher }}
           idrange: ${{ github.event.inputs.idrange }}
           sampleCode: ${{ github.event.inputs.sampleCode }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -144,7 +144,7 @@ jobs:
           environmentName: ${{ github.event.inputs.environmentName }}
           project: ${{ github.event.inputs.project }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
           adminCenterApiCredentials: ${{ steps.SetAdminCenterApiCredentials.outputs.adminCenterApiCredentials }}
 
       - name: Finalize the workflow

--- a/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreatePerformanceTestApp.yaml
@@ -96,7 +96,7 @@ jobs:
           idrange: ${{ github.event.inputs.idrange }}
           sampleCode: ${{ github.event.inputs.sampleCode }}
           sampleSuite: ${{ github.event.inputs.sampleSuite }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/AppSource App/.github/workflows/CreateRelease.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateRelease.yaml
@@ -365,7 +365,7 @@ jobs:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
   PostProcess:
     needs: [ CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]

--- a/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
+++ b/Templates/AppSource App/.github/workflows/CreateTestApp.yaml
@@ -91,7 +91,7 @@ jobs:
           publisher: ${{ github.event.inputs.publisher }}
           idrange: ${{ github.event.inputs.idrange }}
           sampleCode: ${{ github.event.inputs.sampleCode }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/AppSource App/.github/workflows/IncrementVersionNumber.yaml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           projects: ${{ github.event.inputs.projects }}
           versionNumber: ${{ github.event.inputs.versionNumber }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -72,7 +72,7 @@ jobs:
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
-          downloadLatest: ${{ env.downloadLatest }} ${{ fromJson(env.settings).inputs.downloadLatest || 'true' }}
+          downloadLatest: ${{ fromJson(env.settings).inputs.downloadLatest || 'true' }}
           update: 'Y'
           templateUrl: ${{ fromJson(env.settings).inputs.templateUrl || fromJson(env.settings).templateUrl }}
           directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -76,6 +76,7 @@ jobs:
           update: 'Y'
           templateUrl: ${{ fromJson(env.settings).inputs.templateUrl || fromJson(env.settings).templateUrl }}
           directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
+          commitMessageSuffix: ${{ fromJson(env.settings).inputs.commitMessageSuffix || fromJson(env.settings).commitOptions.messageSuffix }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -15,6 +15,10 @@ on:
         description: Direct Commit?
         type: boolean
         default: false
+      commitMessageSuffix:
+        description: Commit Message Suffix
+        required: false
+        default: ''
 
 permissions:
   actions: read

--- a/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -63,44 +63,15 @@ jobs:
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
-      - name: Override templateUrl
-        env:
-          templateUrl: ${{ github.event.inputs.templateUrl }}
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $templateUrl = $ENV:templateUrl
-          if ($templateUrl) {
-            Write-Host "Using Template Url: $templateUrl"
-            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
-          }
-
-      - name: Calculate Input
-        env:
-          directCommit: '${{ github.event.inputs.directCommit }}'
-          downloadLatest: ${{ github.event.inputs.downloadLatest }}
-          eventName: ${{ github.event_name }}
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $directCommit = $ENV:directCommit
-          $downloadLatest = $ENV:downloadLatest
-          Write-Host $ENV:eventName
-          if ($ENV:eventName -eq 'schedule') {
-            Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit and DownloadLatest to true"
-            $directCommit = 'true'
-            $downloadLatest = 'true'
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "directCommit=$directCommit"
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
-
       - name: Update AL-Go system files
         uses: microsoft/AL-Go-Actions/CheckForUpdates@main
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
-          downloadLatest: ${{ env.downloadLatest }}
+          downloadLatest: ${{ env.downloadLatest }} ${{ fromJson(env.settings).inputs.downloadLatest || 'true' }}
           update: 'Y'
-          templateUrl: ${{ env.templateUrl }}
-          directCommit: ${{ env.directCommit }}
+          templateUrl: ${{ fromJson(env.settings).inputs.templateUrl || fromJson(env.settings).templateUrl }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           project: ${{ github.event.inputs.project }}
           url: ${{ github.event.inputs.url }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateApp.yaml
@@ -90,7 +90,7 @@ jobs:
           publisher: ${{ github.event.inputs.publisher }}
           idrange: ${{ github.event.inputs.idrange }}
           sampleCode: ${{ github.event.inputs.sampleCode }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -144,7 +144,7 @@ jobs:
           environmentName: ${{ github.event.inputs.environmentName }}
           project: ${{ github.event.inputs.project }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
           adminCenterApiCredentials: ${{ steps.SetAdminCenterApiCredentials.outputs.adminCenterApiCredentials }}
 
       - name: Finalize the workflow

--- a/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreatePerformanceTestApp.yaml
@@ -96,7 +96,7 @@ jobs:
           idrange: ${{ github.event.inputs.idrange }}
           sampleCode: ${{ github.event.inputs.sampleCode }}
           sampleSuite: ${{ github.event.inputs.sampleSuite }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateRelease.yaml
@@ -365,7 +365,7 @@ jobs:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           versionNumber: ${{ github.event.inputs.updateVersionNumber }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
   PostProcess:
     needs: [ CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]

--- a/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/CreateTestApp.yaml
@@ -91,7 +91,7 @@ jobs:
           publisher: ${{ github.event.inputs.publisher }}
           idrange: ${{ github.event.inputs.idrange }}
           sampleCode: ${{ github.event.inputs.sampleCode }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/IncrementVersionNumber.yaml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           projects: ${{ github.event.inputs.projects }}
           versionNumber: ${{ github.event.inputs.versionNumber }}
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -15,6 +15,10 @@ on:
         description: Direct Commit?
         type: boolean
         default: false
+      commitMessageSuffix:
+        description: Commit Message Suffix
+        required: false
+        default: ''
 
 permissions:
   actions: read
@@ -72,6 +76,7 @@ jobs:
           update: 'Y'
           templateUrl: ${{ fromJson(env.settings).inputs.templateUrl || fromJson(env.settings).templateUrl }}
           directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
+          commitMessageSuffix: ${{ fromJson(env.settings).inputs.commitMessageSuffix || fromJson(env.settings).commitOptions.messageSuffix }}
 
       - name: Finalize the workflow
         if: always()

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -63,44 +63,15 @@ jobs:
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
-      - name: Override templateUrl
-        env:
-          templateUrl: ${{ github.event.inputs.templateUrl }}
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $templateUrl = $ENV:templateUrl
-          if ($templateUrl) {
-            Write-Host "Using Template Url: $templateUrl"
-            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
-          }
-
-      - name: Calculate Input
-        env:
-          directCommit: '${{ github.event.inputs.directCommit }}'
-          downloadLatest: ${{ github.event.inputs.downloadLatest }}
-          eventName: ${{ github.event_name }}
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $directCommit = $ENV:directCommit
-          $downloadLatest = $ENV:downloadLatest
-          Write-Host $ENV:eventName
-          if ($ENV:eventName -eq 'schedule') {
-            Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit and DownloadLatest to true"
-            $directCommit = 'true'
-            $downloadLatest = 'true'
-          }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "directCommit=$directCommit"
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
-
       - name: Update AL-Go system files
         uses: microsoft/AL-Go-Actions/CheckForUpdates@main
         with:
           shell: powershell
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
-          downloadLatest: ${{ env.downloadLatest }}
+          downloadLatest: ${{ env.downloadLatest }} ${{ fromJson(env.settings).inputs.downloadLatest || 'true' }}
           update: 'Y'
-          templateUrl: ${{ env.templateUrl }}
-          directCommit: ${{ env.directCommit }}
+          templateUrl: ${{ fromJson(env.settings).inputs.templateUrl || fromJson(env.settings).templateUrl }}
+          directCommit: ${{ fromJson(env.settings).inputs.directCommit || fromJson(env.settings).commitOptions.directCommit }}
 
       - name: Finalize the workflow
         if: always()


### PR DESCRIPTION
* Inputs are added to the settings object
* Inputs are **only** added if the workflow is manually triggered.
* Workflows that take inputs can use expressions in GitHub to use inputs and fallback to settings if no input was provided (either because it was empty or because it was scheduled)


- [ ] Wire a few more workflows to allow custom commit message (e.g. Create Release / Increment Version Number) 